### PR TITLE
add jinja2 quote filter

### DIFF
--- a/differ/core.py
+++ b/differ/core.py
@@ -10,6 +10,8 @@ from uuid import uuid4
 import jinja2
 import yaml
 
+from .template import JINJA_ENVIRONMENT
+
 
 class TraceHook:
     """
@@ -209,7 +211,7 @@ class InputFile:
         :returns: the Jinja2 template object for the input file
         """
         if not self._template:
-            self._template = jinja2.Template(self.source.read_text())
+            self._template = JINJA_ENVIRONMENT.from_string(self.source.read_text())
         return self._template
 
     @classmethod
@@ -281,7 +283,7 @@ class TraceTemplate:
         :returns: the Jinja2 template object for the command line arguments
         """
         if not self._arguments_template:
-            self._arguments_template = jinja2.Template(self.arguments)
+            self._arguments_template = JINJA_ENVIRONMENT.from_string(self.arguments)
         return self._arguments_template
 
     @property

--- a/differ/template.py
+++ b/differ/template.py
@@ -1,0 +1,43 @@
+"""
+Jinja2 Environment and template functions. This module provides the ``JINJA_ENVIRONMENT`` variable
+that contains all custom filters that are available to command line arguments and input file
+templates.
+"""
+import shlex
+
+from jinja2 import Environment
+
+JINJA_ENVIRONMENT = Environment()
+
+
+def quote_filter(s: str) -> str:
+    """
+    A ``quote`` filter that quotes the input string so that it can be used within a command line
+    argument or input file. This method calls :func:`shlex.quote` and can be used like so:
+
+    .. code-block:: yaml
+
+    - templates:
+      - arguments: '--value {{name | quote}}'
+        variables:
+          name:
+            type: str
+            values:
+              - 'this value contains spaces'
+
+    In this example, the generated command line arguments generated would be:
+
+    .. code-block:: bash
+
+        /path/to/binary --value 'this value contains spaces'
+
+    :param s: input string to quote
+    :returns: quoted string
+    """
+    return shlex.quote(s)
+
+
+#: The Jinja2 Environment will custom filters.
+#:
+#: - :func:`quote_filter` - the ``quote`` filter
+JINJA_ENVIRONMENT.filters['quote'] = quote_filter

--- a/test/test_template.py
+++ b/test/test_template.py
@@ -1,0 +1,15 @@
+from unittest.mock import patch
+
+from differ import template
+
+
+class TestQuoteFilter:
+    @patch.object(template.shlex, 'quote')
+    def test_quote_filter_call(self, mock_quote):
+        s = object()
+        assert template.quote_filter(s) is mock_quote.return_value
+        mock_quote.assert_called_once_with(s)
+
+    def test_quote_filter_template(self):
+        templ = template.JINJA_ENVIRONMENT.from_string('hello {{name | quote}}')
+        assert templ.render(name='duke leto') == "hello 'duke leto'"


### PR DESCRIPTION
This adds a new `quote` filter to jinja2 templates for both input files and command line arguments. The `quote` filter wraps the input string in shell quotes so that special characters are treated as part of the string, for example:

```
# template, command line arguments
hello, {{name | quote}}!

# populated command line arguments
hello, 'duke leto'!
```

Closes #3 